### PR TITLE
Fix Bundle by using UxZoomBundle so expected alias is ux_zoom

### DIFF
--- a/src/DependencyInjection/UxZoomExtension.php
+++ b/src/DependencyInjection/UxZoomExtension.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\WebpackEncoreBundle\Twig\StimulusTwigExtension;
 use Twig\Environment;
 
-class ZoomExtension extends Extension
+class UxZoomExtension extends Extension
 {
     public function load(array $configs, ContainerBuilder $container)
     {

--- a/src/UxZoomBundle.php
+++ b/src/UxZoomBundle.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  *
  * @final
  */
-class ZoomBundle extends Bundle
+class UxZoomBundle extends Bundle
 {
     public function getPath(): string
     {


### PR DESCRIPTION
The bundle need to be called `UxZoomBundle` if you want to use `ux_zoom` else changes in `Bundle` and `Extension` class is required to get `ux_zoom` config work.


<img width="1656" alt="Bildschirmfoto 2022-12-18 um 14 53 45" src="https://user-images.githubusercontent.com/1698337/208302295-98c8b970-d6eb-474c-bd03-f4aca2e332d3.png">

